### PR TITLE
Apply adaptive low-pass before decimation

### DIFF
--- a/script.js
+++ b/script.js
@@ -240,7 +240,8 @@ function biquadBandpassSample1(x, fc, q, fs, state){
 }
 
 function processBuffer(data, sr, {fsOut, bit, cabDelay}){
-  const lp = simpleOnePoleLP(data, sr, 4500); // 明るめ
+  const cutoff = Math.min(4500, fsOut/2 - 100); // Nyquist安全マージン
+  const lp = simpleOnePoleLP(data, sr, cutoff); // ローパス（エイリアス防止）
 
   // 量子化（ビットクラッシュ）
   const step = Math.pow(2, bit)-1;


### PR DESCRIPTION
## Summary
- Compute a dynamic cutoff at `min(4500, fsOut/2 - 100)` and feed it to `simpleOnePoleLP`
- Prevent aliasing by filtering before downsampling

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_689899cd80b083298e97d2822c38e05e