### PR TITLE
Handle STR-like consonant clusters in phoneme parser

### DIFF
--- a/script.js
+++ b/script.js
@@ -80,6 +80,12 @@ function toPhonemes(input) {
       if (tok.slice(i).startsWith('CH')) { c='CH'; i+=2; }
       else if (tok.slice(i).startsWith('SH')) { c='SH'; i+=2; }
       else if (tok.slice(i).startsWith('TS')) { c='TS'; i+=2; }
+      else if (
+        tok[i] === 'S' &&
+        i + 2 < tok.length &&
+        CONS.test(tok[i + 1]) &&
+        tok[i + 2] === 'R'
+      ) { c = tok.slice(i, i + 3); i += 3; }
       else if (CONS.test(tok[i])) {
         c = tok[i]; i++;
         if (i<tok.length && /[RLY]/.test(tok[i])) { c += tok[i]; i++; }

--- a/test/toPhonemes.test.js
+++ b/test/toPhonemes.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+// Load script.js into a sandboxed context with minimal DOM stubs
+const code = fs.readFileSync(path.join(__dirname, '..', 'script.js'), 'utf8');
+const context = {
+  console,
+  document: { getElementById: () => ({}) },
+  window: {}
+};
+vm.createContext(context);
+vm.runInContext(code, context);
+const toPhonemes = context.toPhonemes;
+
+const stringRes = toPhonemes('STRING');
+assert.strictEqual(stringRes[0].c, 'STR');
+assert.strictEqual(stringRes[0].v, 'I');
+
+const sprintRes = toPhonemes('SPRINT');
+assert.strictEqual(sprintRes[0].c, 'SPR');
+assert.strictEqual(sprintRes[0].v, 'I');
+
+console.log('toPhonemes cluster tests passed');


### PR DESCRIPTION
## Summary
- Detect triple consonant clusters starting with `S` and ending with `R` (e.g. STR, SPR, SCR) before generic consonant logic.
- Add unit tests ensuring words like `STRING` and `SPRINT` map these clusters to a single syllable with the following vowel.

## Testing
- `node test/toPhonemes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689899ca067883298cf09dde4cb3941b