### PR TITLE
Add optional vocoder ring modulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
           <label>フォルマント強調 <input type="range" id="formantGain" min="0.5" max="2.0" step="0.01" value="1.2"></label>
           <label>ディレイ(筐体鳴り) <input type="range" id="delay" min="0" max="0.08" step="0.002" value="0.045"> s</label>
           <label><input type="checkbox" id="brightConsonant" checked> 子音シャリ感</label>
+          <label><input type="checkbox" id="vocoder"> Vocoder Voice</label>
         </div>
       </details>
     </section>


### PR DESCRIPTION
## Summary
- add `vocoder` flag to post-processing, applying 150 Hz saw-wave ring modulation with compression
- expose "Vocoder Voice" checkbox and pass option into renderer

## Testing
- `node test/toPhonemes.test.js`
- `node - <<'NODE' ... >>` (rendered ATTACK and MISSION with vocoder option)


------
https://chatgpt.com/codex/tasks/task_e_689b3df246f083299c49f228b9cb6878