### PR TITLE
feat: allow injecting custom RNG

### DIFF
--- a/script.js
+++ b/script.js
@@ -168,7 +168,7 @@ function baseFormantsFor(syl){
 let bpStates = [{x1:0,x2:0,y1:0,y2:0},{x1:0,x2:0,y1:0,y2:0},{x1:0,x2:0,y1:0,y2:0}];
 let currentCtx = null, currentSource = null;
 
-async function render(exportWav=false){
+async function render(exportWav=false, rng = Math.random){
   // BPF状態リセット
   bpStates = [{x1:0,x2:0,y1:0,y2:0},{x1:0,x2:0,y1:0,y2:0},{x1:0,x2:0,y1:0,y2:0}];
 
@@ -214,7 +214,7 @@ async function render(exportWav=false){
     const sylSamples = frames * frame;
     const fadeSamps = Math.min(Math.floor(sr * 0.005), Math.floor(sylSamples / 2));
     for(let k=0;k<frames;k++){
-      const jitter = (Math.random()-0.5)*4;
+      const jitter = (rng()-0.5)*4;
       const period = Math.max(1, Math.floor(sr/(f0 + jitter)));
 
       for(let n=0;n<frame;n++){
@@ -227,11 +227,11 @@ async function render(exportWav=false){
           const width = Math.max(1, Math.floor(period * 0.05)); // ★5%
           exc = (ph < width) ? 1.0 : 0.0;
         } else {
-          exc = (Math.random()*2 - 1);
+          exc = (rng()*2 - 1);
         }
         // 有声/無声でノイズ量を切り替える（有声は0.05固定）
         const effectiveNoiseAmt = voiced ? 0.05 : noiseAmt;
-        exc = exc*(1-effectiveNoiseAmt) + (Math.random()*2-1)*effectiveNoiseAmt;
+        exc = exc*(1-effectiveNoiseAmt) + (rng()*2-1)*effectiveNoiseAmt;
 
         // アタック/ディケイエンベロープ（5ms）
         const pos = k * frame + n;
@@ -260,7 +260,7 @@ async function render(exportWav=false){
             const r = (sampleInSyl - (totalSamples - transSamples)) / transSamples;
             fcTarget = baseFormants[b] + (nextFormants[b] - baseFormants[b]) * r;
           }
-          const fc = v ? fcTarget : fcTarget * (1 + (Math.random()-0.5)*0.1);
+          const fc = v ? fcTarget : fcTarget * (1 + (rng()-0.5)*0.1);
           const bw = baseBw[b];
           const q  = Math.max(0.707, fc/(2*bw));
           y += gains[b] * biquadBandpassSample1(exc, fc, q, sr, bpStates[b]);

--- a/synth.js
+++ b/synth.js
@@ -85,9 +85,9 @@ function biquadBandpassSample(x, fc, q, fs) {
  * @param {Object} params - Synthesis parameters
  * @returns {Float32Array} - Raw audio data
  */
-function synthesize(phon, params) {
-  const { 
-    sr, baseF0, rate, noiseAmt, brightConsonant = false 
+function synthesize(phon, params, rng = Math.random) {
+  const {
+    sr, baseF0, rate, noiseAmt, brightConsonant = false
   } = params;
   
   // Reset BPF state for clean synthesis
@@ -117,7 +117,7 @@ function synthesize(phon, params) {
     const sylSamples = frames * frame;
     const fadeSamps = Math.min(Math.floor(sr * 0.005), Math.floor(sylSamples / 2));
     for (let k = 0; k < frames; k++) {
-      const jitter = (Math.random() - 0.5) * 4;
+      const jitter = (rng() - 0.5) * 4;
       const period = Math.max(1, Math.floor(sr / (f0 + jitter)));
 
       for (let n = 0; n < frame; n++) {
@@ -130,7 +130,7 @@ function synthesize(phon, params) {
           const ph = (idx % period);
           exc = (ph < 2) ? 1.0 : 0.0;
         } else {
-          exc = (Math.random() * 2 - 1);
+          exc = (rng() * 2 - 1);
         }
 
 
@@ -155,7 +155,7 @@ function synthesize(phon, params) {
           // 子音シャリ感: 子音時は第3フォルマントを+10%～+15%ランダム
           let fc = baseFormants[b];
           if (!v && b === 2 && brightConsonant) {
-            fc *= (1 + 0.1 + Math.random() * 0.05);
+            fc *= (1 + 0.1 + rng() * 0.05);
           }
 
           const bw = baseBw[b];

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+
+function seededRng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+(async () => {
+  const { synthesize } = await import('../synth.js');
+
+  const phon = [{ c: '', v: 'A', len: 140 }];
+  const params = { sr: 8000, baseF0: 100, rate: 1, noiseAmt: 0.05 };
+
+  const rng1 = seededRng(1);
+  const out1 = synthesize(phon, params, rng1);
+  const rng2 = seededRng(1);
+  const out2 = synthesize(phon, params, rng2);
+
+  assert.strictEqual(out1.length, out2.length);
+  for (let i = 0; i < out1.length; i++) {
+    assert.strictEqual(out1[i], out2[i]);
+  }
+
+  console.log('synthesize deterministic output test passed');
+})();


### PR DESCRIPTION
## Summary
- add optional RNG parameter to `synthesize` and browser `render`
- replace Math.random calls with provided generator
- cover deterministic behavior with seeded test

## Testing
- `node test/toPhonemes.test.js`
- `node test/synthesize.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689b4166c44c832989404b9d81031144