### PR TITLE
Refactor toPhonemes into shared module

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 // VLM-5030風 ルールTTS (#KGNINJA)
 // テキスト→CV音素→有声/無声励起→3フォルマントBPF(並列)→8kHz/量子化→WAV
+import { toPhonemes } from './phoneme.js';
 
 // Global debug flag. Set to true to enable detailed logging.
 window.DEBUG = false;
@@ -50,96 +51,7 @@ $("speak").onclick = async () => render(false);
 $("export").onclick = async () => render(true);
 
 // ==== 1) Grapheme→Phoneme（子音クラスタ対応） ====
-function toPhonemes(input) {
-  let s = (input || "").trim()
-    .replace(/[!?.、。]/g, " ")
-    .replace(/\s+/g, " ")
-    .toUpperCase();
-
-  // カタカナ→ローマ字（主要・拗音・促音・長音）
-  const kataMap = {
-    'ァ':'A','ィ':'I','ゥ':'U','ェ':'E','ォ':'O',
-    'ア':'A','イ':'I','ウ':'U','エ':'E','オ':'O',
-    'カ':'KA','キ':'KI','ク':'KU','ケ':'KE','コ':'KO',
-    'サ':'SA','シ':'SHI','ス':'SU','セ':'SE','ソ':'SO',
-    'タ':'TA','チ':'CHI','ツ':'TSU','テ':'TE','ト':'TO',
-    'ナ':'NA','ニ':'NI','ヌ':'NU','ネ':'NE','ノ':'NO',
-    'ハ':'HA','ヒ':'HI','フ':'FU','ヘ':'HE','ホ':'HO',
-    'マ':'MA','ミ':'MI','ム':'MU','メ':'ME','モ':'MO',
-    'ヤ':'YA','ユ':'YU','ヨ':'YO',
-    'ラ':'RA','リ':'RI','ル':'RU','レ':'RE','ロ':'RO',
-    'ワ':'WA','ヲ':'O','ン':'N',
-    'ガ':'GA','ギ':'GI','グ':'GU','ゲ':'GE','ゴ':'GO',
-    'ザ':'ZA','ジ':'JI','ズ':'ZU','ゼ':'ZE','ゾ':'ZO',
-    'ダ':'DA','ヂ':'JI','ヅ':'ZU','デ':'DE','ド':'DO',
-    'バ':'BA','ビ':'BI','ブ':'BU','ベ':'BE','ボ':'BO',
-    'パ':'PA','ピ':'PI','プ':'PU','ペ':'PE','ポ':'PO',
-    'キャ':'KYA','キュ':'KYU','キョ':'KYO',
-    'シャ':'SHA','シュ':'SHU','ショ':'SHO',
-    'チャ':'CHA','チュ':'CHU','チョ':'CHO',
-    'ジャ':'JA','ジュ':'JU','ジョ':'JO',
-    'リャ':'RYA','リュ':'RYU','リョ':'RYO',
-    'ッ':'Q', 'ー':'-'
-  };
-  s = s.replace(/(キャ|キュ|キョ|シャ|シュ|ショ|チャ|チュ|チョ|ジャ|ジュ|ジョ|リャ|リュ|リョ)/g, m=>kataMap[m]||m);
-  s = s.replace(/[ァ-ンー]/g, ch => kataMap[ch] || ch);
-
-  // 英語簡易置換（必要に応じて拡張）
-  s = s.replace(/\bFIRE\b/g, "FAI YA")
-       .replace(/\bDESTROY\b/g, "DES TROI")
-       .replace(/\bALL\b/g, "AUL")
-       .replace(/\bTHEM\b/g, "ZEM")
-       .replace(/\bATTACK\b/g, "A TAK")
-       .replace(/\bMISSION\b/g, "MI SHON")
-       .replace(/\bSTART\b/g, "STAAT")
-       .replace(/\bLASER\b/g, "LEI ZER")
-       .replace(/\bLAUNCH\b/g, "LON CH")
-       .replace(/\bWARNING\b/g, "WOA NING")
-       .replace(/\bREADY\b/g, "RE DI");
-
-  const syl = [];
-  const tokens = s.split(/\s+/).filter(Boolean);
-  const VOW = /[AIUEO]/;
-  const CONS = /[BCDFGHJKLMNPQRSTVWXZ]/;
-
-  tokens.forEach(tok=>{
-    tok = tok.replace(/([AIUEO])-+/g, "$1$1"); // 長音処理
-    let i = 0;
-    while (i < tok.length) {
-      if (tok[i] === 'Q') { syl.push({c:'',v:'',len:0, gem:true}); i++; continue; }
-
-      // 子音クラスタ（CH/SH/TS、+R/L/Y連結、先行S等）
-      let c = '';
-      if (tok.slice(i).startsWith('CH')) { c='CH'; i+=2; }
-      else if (tok.slice(i).startsWith('SH')) { c='SH'; i+=2; }
-      else if (tok.slice(i).startsWith('TS')) { c='TS'; i+=2; }
-      else if (
-        tok[i] === 'S' &&
-        i + 2 < tok.length &&
-        CONS.test(tok[i + 1]) &&
-        tok[i + 2] === 'R'
-      ) { c = tok.slice(i, i + 3); i += 3; }
-      else if (CONS.test(tok[i])) {
-        c = tok[i]; i++;
-        if (i<tok.length && /[RLY]/.test(tok[i])) { c += tok[i]; i++; }
-        if (i<tok.length && CONS.test(tok[i]) && !VOW.test(tok[i])) { c += tok[i]; i++; }
-      }
-
-      // 母音を必ず1つ
-      let v = '';
-      if (i<tok.length && VOW.test(tok[i])) { v = tok[i]; i++; }
-      else if (tok[i]==='Y' && VOW.test(tok[i+1])) { c += 'Y'; v = tok[i+1]; i+=2; }
-      else if (tok[i]==='N' && (i===tok.length-1 || !VOW.test(tok[i+1]))) { syl.push({c:'N',v:'',len:60}); i++; continue; }
-      else { i++; continue; }
-
-      syl.push({ c, v, len: 140 }); // 1音節=140ms（短すぎ回避）
-    }
-  });
-
-  // 促音→burst
-  for (let j=0;j<syl.length-1;j++) if (syl[j].gem){ syl[j].len=0; syl[j+1].burst=true; }
-  return syl.filter(s=>s.len>0 || s.c==='N');
-}
+// toPhonemes is imported from phoneme.js
 
 // ==== 2) 合成パラメータ ====
 const VOWEL_FORMANTS = {

--- a/test/toPhonemes.test.js
+++ b/test/toPhonemes.test.js
@@ -1,25 +1,22 @@
 const assert = require('assert');
-const fs = require('fs');
-const vm = require('vm');
 const path = require('path');
+const { pathToFileURL } = require('url');
 
-// Load script.js into a sandboxed context with minimal DOM stubs
-const code = fs.readFileSync(path.join(__dirname, '..', 'script.js'), 'utf8');
-const context = {
-  console,
-  document: { getElementById: () => ({ addEventListener: () => {} }) },
-  window: {}
-};
-vm.createContext(context);
-vm.runInContext(code, context);
-const toPhonemes = context.toPhonemes;
+async function load() {
+  return await import(pathToFileURL(path.join(__dirname, '..', 'phoneme.js')).href);
+}
 
-const stringRes = toPhonemes('STRING');
-assert.strictEqual(stringRes[0].c, 'STR');
-assert.strictEqual(stringRes[0].v, 'I');
+(async () => {
+  const { toPhonemes } = await load();
 
-const sprintRes = toPhonemes('SPRINT');
-assert.strictEqual(sprintRes[0].c, 'SPR');
-assert.strictEqual(sprintRes[0].v, 'I');
+  const stringRes = toPhonemes('STRING');
+  assert.strictEqual(stringRes[0].c, 'STR');
+  assert.strictEqual(stringRes[0].v, 'I');
 
-console.log('toPhonemes cluster tests passed');
+  const sprintRes = toPhonemes('SPRINT');
+  assert.strictEqual(sprintRes[0].c, 'SPR');
+  assert.strictEqual(sprintRes[0].v, 'I');
+
+  console.log('toPhonemes cluster tests passed');
+})();
+


### PR DESCRIPTION
## Summary
- centralize `toPhonemes` in `phoneme.js` and export it for reuse
- import shared `toPhonemes` in `script.js` instead of maintaining a copy
- update unit test to load the new module

## Testing
- `node test/toPhonemes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689b41634eb083299143caf29adc69fe